### PR TITLE
Add custom logger to capture warnings and errors

### DIFF
--- a/CCX-VMO2-Optimizly-MultiClient/Logger.swift
+++ b/CCX-VMO2-Optimizly-MultiClient/Logger.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Optimizely
+
+enum LogLevel: String {
+    case warning = "⚠️ Warning"
+    case error = "❌ Error"
+}
+
+final class Logger {
+    static let shared = Logger()
+    private(set) var warnings: [String] = []
+    private(set) var errors: [String] = []
+
+    private init() {}
+
+    private func log(_ level: LogLevel, _ message: String) {
+        switch level {
+        case .warning:
+            warnings.append(message)
+        case .error:
+            errors.append(message)
+        }
+        print("\(level.rawValue): \(message)")
+    }
+
+    func warning(_ message: String) {
+        log(.warning, message)
+    }
+
+    func error(_ message: String) {
+        log(.error, message)
+    }
+}
+
+final class OptimizelyLoggerAdapter: OptimizelyLogger {
+    func log(level: OptimizelyLogLevel, message: String) {
+        switch level {
+        case .warning:
+            Logger.shared.warning(message)
+        case .error:
+            Logger.shared.error(message)
+        default:
+            break
+        }
+    }
+}
+

--- a/CCX-VMO2-Optimizly-MultiClient/OptimizelyClientHelper.swift
+++ b/CCX-VMO2-Optimizly-MultiClient/OptimizelyClientHelper.swift
@@ -5,7 +5,8 @@ struct OptimizelyClientHelper {
     static func instantiateAllClients() -> [OptimizelyEnvironments: OptimizelyClient] {
         var clients: [OptimizelyEnvironments: OptimizelyClient] = [:]
         for env in OptimizelyEnvironments.allCases {
-            let client = OptimizelyClient(sdkKey: env.rawValue, defaultLogLevel: .error)
+            let logger = OptimizelyLoggerAdapter()
+            let client = OptimizelyClient(sdkKey: env.rawValue, logger: logger, defaultLogLevel: .warning)
             clients[env] = client
         }
         return clients
@@ -13,9 +14,12 @@ struct OptimizelyClientHelper {
 
     static func start(clients: [OptimizelyEnvironments: OptimizelyClient], completion: @escaping () -> Void) {
         let group = DispatchGroup()
-        for (_, client) in clients {
+        for (env, client) in clients {
             group.enter()
-            client.start { _ in
+            client.start { result in
+                if case let .failure(error) = result {
+                    Logger.shared.error("Failed to start client for \(env): \(error.localizedDescription)")
+                }
                 group.leave()
             }
         }
@@ -58,6 +62,9 @@ struct OptimizelyClientHelper {
                 let decision = user.decide(key: flag)
                 let supported = env.activeFlags.contains(flag)
                 envResults[flag] = (decision, supported)
+                if !supported {
+                    Logger.shared.warning("Flag \(flag) is not supported in \(env)")
+                }
                 print("Env: \(env) Flag: \(flag) Supported: \(supported) Variation: \(decision.variationKey ?? \"\") Enabled: \(decision.enabled)")
             }
             results[env] = envResults


### PR DESCRIPTION
## Summary
- introduce reusable `Logger` to store warnings and errors and print them
- wire Optimizely clients to logger and report unsupported flags and client start failures

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb3dc450832296c6d3788f586c73